### PR TITLE
Return the globals instead of logging as console can be overwritten

### DIFF
--- a/log-globals.js
+++ b/log-globals.js
@@ -29,5 +29,5 @@
 		return ret;
 	}
 
-	console.log(detectGlobals());
+	return detectGlobals();
 })();


### PR DESCRIPTION
Same exact outcome.
This guarantees it works on any site, regardless of console manipulation.